### PR TITLE
close file descriptors to avoid holding unlinked files open

### DIFF
--- a/src/swaps.c
+++ b/src/swaps.c
@@ -472,6 +472,8 @@ static memsize_t filesize(const char name[])
   if (unlikely(pos == -1))
     log_perr_str(LOG_WARNING, "Can't determine size of", name, errno);
 
+  close(fd);
+
   return pos;
 }
 
@@ -699,7 +701,10 @@ static bool retire_swapfile(int file)
   unlink(namebuf);
 
 #ifndef NO_CONFIG
-  if (fd != -1) write_data(fd, swapfiles[file].size, true);
+  if (fd != -1) {
+    write_data(fd, swapfiles[file].size, true);
+    close(fd);
+  }
 #endif
 
   swapfiles[file].size = 0;


### PR DESCRIPTION
Avoid leaking file descriptors, in order to free disk space after unlinking files.

Currently the disk space for retired swap files is not freed after they are unlinked if the filesize() function has been called, due to a leaked file descriptor holding the file open. 

There is also a leaked file descriptor in retire_swapfile() when in paranoid mode.