### PR TITLE
Feature/optionally trust mem available

### DIFF
--- a/src/memory.h
+++ b/src/memory.h
@@ -68,6 +68,7 @@ char *set_upper_freelimit(long long pct);
 char *set_freetarget(long long pct);
 char *set_buffer_elasticity(long long pct);
 char *set_cache_elasticity(long long pct);
+char *set_trust_kernel_mem_available(long long dummy);
 
 bool memory_check_config(void);
 #endif

--- a/src/opts.c
+++ b/src/opts.c
@@ -116,6 +116,8 @@ static const struct option options[] =
   "Suppress informational output" },
   { "swappath",		's', at_str,  1, PATH_MAX, set_swappath,
   "Create swapfiles in secure directory s" },
+  { "trust_mem_available", 't', at_none, 0, 0, set_trust_kernel_mem_available,
+  "Trust the value in /proc/meminfo:MemAvailable for the estimate of free space" },
   { "upper_freelimit",	'u', at_num,  0, 100, set_upper_freelimit,
   "Reduce swapspace if more than n% is free" },
   { "verbose",		'v', at_none, 0, 0, set_verbose,

--- a/swapspace.conf
+++ b/swapspace.conf
@@ -43,5 +43,6 @@
 # again.  The default cooldown period is about 10 minutes.
 #cooldown=600
 
-# Trust the value in /proc/meminfo:MemAvailable as estimate for free RAM
-trust_mem_available
+# Comment out to Trust the value in /proc/meminfo:MemAvailable as
+# estimate for free RAM instead of using a self-computed estimate
+#trust_mem_available

--- a/swapspace.conf
+++ b/swapspace.conf
@@ -43,3 +43,5 @@
 # again.  The default cooldown period is about 10 minutes.
 #cooldown=600
 
+# Trust the value in /proc/meminfo:MemAvailable as estimate for free RAM
+trust_mem_available


### PR DESCRIPTION
Optionally just use /proc/meminfo MemAvailable
```
MemTotal:       30773580 kB
MemFree:        10416436 kB
MemAvailable:   15917164 kB
Buffers:             124 kB
...
```
instead of computing an estimate based on buffers and cached pages.